### PR TITLE
WCP-1084 Add feet and meter unit to meter counter

### DIFF
--- a/CommonItems/ConnectionBox.qml
+++ b/CommonItems/ConnectionBox.qml
@@ -50,12 +50,14 @@ Rectangle {
         TextField {
             id: ip
             selectByMouse: true
+            text: "127.0.0.1"
         }
 
         Label { text: "Port:"}
         TextField {
             id: port
             selectByMouse: true
+            text: "8095"
             validator: IntValidator{}
         }
     }

--- a/CommonItems/ConnectionBox.qml
+++ b/CommonItems/ConnectionBox.qml
@@ -49,12 +49,13 @@ Rectangle {
         Label { text: "IP:" }
         TextField {
             id: ip
-
+            selectByMouse: true
         }
 
         Label { text: "Port:"}
         TextField {
             id: port
+            selectByMouse: true
             validator: IntValidator{}
         }
     }

--- a/CommonItems/ControlMessageBox.qml
+++ b/CommonItems/ControlMessageBox.qml
@@ -83,6 +83,7 @@ Rectangle {
         }
         TextField {
             id: errorDesc
+            selectByMouse: true
             onTextEdited: {
                 errorText = errorDesc.text
             }

--- a/CommonItems/FreeTextBox.qml
+++ b/CommonItems/FreeTextBox.qml
@@ -80,6 +80,7 @@ Rectangle {
 
             TextField {
                 id: textFieldInput
+                selectByMouse: true
                 Layout.preferredWidth:  200
             }
             SpinBox {

--- a/CommonItems/MessagesBox.qml
+++ b/CommonItems/MessagesBox.qml
@@ -28,6 +28,7 @@ Rectangle {
     }
 
     ScrollView {
+        id: scrollView
         anchors.top: messageTitle.bottom
         anchors.topMargin: Design.smallMargin
         anchors.left: parent.left
@@ -39,12 +40,13 @@ Rectangle {
 
         clip: true
 
-        TextEdit {
+        TextArea {
             id: textEdit
 
             anchors.fill: parent
             wrapMode: TextEdit.WrapAnywhere
             selectByMouse: true
+
         }
     }
 }

--- a/CommonItems/MonitoringMessageBox.qml
+++ b/CommonItems/MonitoringMessageBox.qml
@@ -11,6 +11,7 @@ Rectangle {
     property alias object: object.text
     property alias value: value.text
     property alias meterCounterValue: meterCounterValue.text
+    property string meterCounterUnit
 
     signal sendObjectStatusIndClicked
     signal sendMeterCounterStatusIndClicked
@@ -52,11 +53,13 @@ Rectangle {
         Label { text: "Object:" }
         TextField {
             id: object
+            selectByMouse: true
         }
 
         Label { text: "Value:"}
         TextField {
             id: value
+            selectByMouse: true
         }
     }
 
@@ -95,14 +98,44 @@ Rectangle {
         TextField {
             id: meterCounterValue
             width: 10
-            validator: IntValidator{}
+            selectByMouse: true
+            validator: DoubleValidator {
+                notation: DoubleValidator.StandardNotation
+            }
         }
+    }
+
+    GridLayout {
+        id: meterCounterUnitBox
+        columns: 2
+        rowSpacing: Design.smallMargin
+        columnSpacing: Design.smallMargin
+        anchors {
+            top: meterCounterBox.bottom
+            topMargin: Design.mediumMargin
+            left: parent.left
+            leftMargin: Design.mediumMargin
+            right: parent.right
+            rightMargin: Design.mediumMargin
+        }
+
+        Label { text: "Meter Counter Unit:"}
+        ComboBox {
+            model: ListModel {
+                ListElement { text: "meter" }
+                ListElement { text: "feet" }
+            }
+            onCurrentIndexChanged: {
+                meterCounterUnit = (currentIndex === 0 ? "meter" : "feet")
+            }
+        }
+
     }
 
     Button {
         id: updateMeterCounterBtn
         anchors {
-            top: meterCounterBox.bottom
+            top: meterCounterUnitBox.bottom
             topMargin: Design.mediumMargin
             left: parent.left
             leftMargin: Design.mediumMargin

--- a/main.qml
+++ b/main.qml
@@ -68,7 +68,7 @@ Window {
         }
 
         onSendMeterCounterStatusIndClicked: {
-            msgGen.sendMeterCounterValue(meterCounterValue)
+            msgGen.sendMeterCounterValue(meterCounterValue, meterCounterUnit)
         }
     }
 

--- a/messagegenerator.cpp
+++ b/messagegenerator.cpp
@@ -114,18 +114,20 @@ void MessageGenerator::sendControlMessage(const QString& msgName, MessageId msgI
     m_client->sendMessage(createMessage(createHeader(msgName, CONTROL, msgId), createControlRespPayload()));
 }
 
-void MessageGenerator::sendMeterCounterValue(const QString& val)
+void MessageGenerator::sendMeterCounterValue(const QString& val, const QString& unit)
 {
     static const QString METER_COUNTER_STATUS_IND = "METER_COUNTER_STATUS_IND";
 
-    m_client->sendMessage(createMessage(createHeader(METER_COUNTER_STATUS_IND, MONITORING, MESSAGE_ID), createPayload(val)));
+    m_client->sendMessage(createMessage(createHeader(METER_COUNTER_STATUS_IND, MONITORING, MESSAGE_ID),
+                                        createMeterCounterStatusIndPayload(val, unit)));
 }
 
 void MessageGenerator::sendObjectValue(const QString& obj, const QString& val)
 {
     static const QString OBJECT_STATUS_IND = "OBJECT_STATUS_IND";
 
-    m_client->sendMessage(createMessage(createHeader(OBJECT_STATUS_IND, MONITORING, MESSAGE_ID), createPayload(obj, val)));
+    m_client->sendMessage(createMessage(createHeader(OBJECT_STATUS_IND, MONITORING, MESSAGE_ID),
+                                        createObjectStatusIndPayload(obj, val)));
 }
 void MessageGenerator::sendCreateFreeText(const QString& text,
                                         int x,
@@ -167,14 +169,15 @@ QJsonObject MessageGenerator::createHeader(const QString& msgName, const QString
     return header;
 }
 
-QJsonObject MessageGenerator::createPayload(const QString& val)
+QJsonObject MessageGenerator::createMeterCounterStatusIndPayload(const QString& val, const QString& unit)
 {
     QJsonObject payload;
-    payload.insert("value", val.toInt());
+    payload.insert("value", QLocale::system().toDouble(val));
+    payload.insert("unit", unit);
     return payload;
 }
 
-QJsonObject MessageGenerator::createPayload(const QString& obj, const QString& val)
+QJsonObject MessageGenerator::createObjectStatusIndPayload(const QString& obj, const QString& val)
 {
     QJsonObject payload;
     payload.insert("value", QJsonValue::fromVariant(getValueForObject(obj.simplified(), val)));
@@ -188,7 +191,7 @@ QVariant MessageGenerator::getValueForObject(const QString& obj, const QString& 
         obj.contains("levelIndicator", Qt::CaseInsensitive))
         return val.toInt();
     else if (obj.contains("switch", Qt::CaseInsensitive))
-        return (obj == "true" ? true : false);
+        return (val == "true" ? true : false);
     return  val;
 }
 

--- a/messagegenerator.h
+++ b/messagegenerator.h
@@ -32,7 +32,7 @@ public:
     Q_INVOKABLE void connectToHost(const QString& ip = "127.0.0.1", const QString& port = "8082");
     Q_INVOKABLE void disconnectFromHost();
 
-    Q_INVOKABLE void sendMeterCounterValue(const QString& val);
+    Q_INVOKABLE void sendMeterCounterValue(const QString& val, const QString& unit);
     Q_INVOKABLE void sendObjectValue(const QString& obj, const QString& val);
 
     Q_INVOKABLE void updateErrorCode(int errorCode);
@@ -69,8 +69,8 @@ private:
     void sendControlMessage(const QString& msgName, MessageId msgId);
 
     QJsonObject createHeader(const QString& msgName, const QString& msgType, MessageId messageId);
-    QJsonObject createPayload(const QString& obj, const QString& val);
-    QJsonObject createPayload(const QString& val);
+    QJsonObject createObjectStatusIndPayload(const QString& obj, const QString& val);
+    QJsonObject createMeterCounterStatusIndPayload(const QString& val, const QString& unit);
     QVariant getValueForObject(const QString& obj, const QString& val);
     QJsonObject createControlRespPayload();
 

--- a/tcpclient.cpp
+++ b/tcpclient.cpp
@@ -19,6 +19,11 @@ TcpClient::TcpClient(const QString& host, quint32 port)
     });
 }
 
+TcpClient::~TcpClient()
+{
+    disconnect();
+}
+
 void TcpClient::connect()
 {
     m_socket->connectToHost(m_host, m_port);

--- a/tcpclient.h
+++ b/tcpclient.h
@@ -12,6 +12,7 @@ class TcpClient : public QObject
     Q_OBJECT
 public:
     explicit TcpClient(const QString& host, quint32 port);
+    ~TcpClient();
 
     void connect();
     void disconnect();


### PR DESCRIPTION
What was fixed:
1. TextField can be handled by mouse (text can be selected)
2. Text area auto scroll to new message on bottom.
3. Change Meter counter value type from int to double
4. Add meter counter unit (feet or meter)